### PR TITLE
fix(reindex): include ProxyFactory addresses when targeting L2 indexer

### DIFF
--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -26,6 +26,33 @@ from ..models import (
 logger = logging.getLogger(__name__)
 
 
+def _is_unrelated_proxy_creation(
+    indexer,
+    log_receipt,
+    requested_addresses: set,
+) -> bool:
+    """Return True if `log_receipt` is a ProxyCreation event whose `proxy` arg
+    is NOT in `requested_addresses`.
+
+    Used by `_reindex` when targeting `SafeEventsIndexer` with `--addresses`:
+    we append the proxy factory addresses to the eth_getLogs filter so the
+    setup→singleton cross-link can fire (see issue #10), but that filter also
+    returns ProxyCreation events for any other Safe the factory created in
+    the same block range. Drop those so `--addresses` keeps its explicit
+    scope and doesn't silently mutate state for unrelated Safes.
+    """
+    try:
+        decoded = indexer.decode_element(log_receipt)
+    except Exception:
+        return False
+    if not decoded or decoded.get("event") != "ProxyCreation":
+        return False
+    proxy = decoded.get("args", {}).get("proxy")
+    if not proxy:
+        return False
+    return proxy.lower() not in requested_addresses
+
+
 @dataclass
 class IndexingStatus:
     current_block_number: int
@@ -400,11 +427,20 @@ class IndexService:
             # See iotexproject/iotex-transaction-service#10.
             from ..indexers.safe_events_indexer import SafeEventsIndexer
 
+            requested_addresses: Optional[set] = None
             if isinstance(indexer, SafeEventsIndexer):
                 factory_addresses = list(
                     ProxyFactory.objects.values_list("address", flat=True)
                 )
-                addresses = list(addresses) + factory_addresses
+                if factory_addresses:
+                    # Remember the originally-requested Safes so we can drop
+                    # ProxyCreation events from the factory that target other,
+                    # unrelated Safes created in the same block range. Without
+                    # this filter, `--addresses` would silently broaden into
+                    # "also discover and index every Safe the factory created
+                    # in this window", surprising the caller.
+                    requested_addresses = {a.lower() for a in addresses}
+                    addresses = list(addresses) + factory_addresses
         else:
             addresses = list(
                 indexer.database_queryset.values_list("address", flat=True)
@@ -433,6 +469,14 @@ class IndexService:
                     block_number,
                     min(block_number + block_process_limit - 1, stop_block_number),
                 )
+                if requested_addresses is not None:
+                    elements = [
+                        log
+                        for log in elements
+                        if not _is_unrelated_proxy_creation(
+                            indexer, log, requested_addresses
+                        )
+                    ]
                 indexer.process_elements(elements)
                 logger.info(
                     "Current block number %d, found %d traces/events",

--- a/safe_transaction_service/history/services/index_service.py
+++ b/safe_transaction_service/history/services/index_service.py
@@ -17,6 +17,7 @@ from ..models import (
     ModuleTransaction,
     MultisigConfirmation,
     MultisigTransaction,
+    ProxyFactory,
     SafeLastStatus,
     SafeMasterCopy,
     SafeStatus,
@@ -388,6 +389,22 @@ class IndexService:
             # Just process addresses provided
             # No issues on modifying the indexer as we should be provided with a new instance
             indexer.IGNORE_ADDRESSES_ON_LOG_FILTER = False
+            # L2 indexers (SafeEventsIndexer) rely on ProxyCreation events emitted
+            # by the proxy factory to populate setup InternalTx.to with the master copy
+            # (see SafeEventsIndexer._process_decoded_element's ProxyCreation branch).
+            # The factory emits at its own address, not the Safe's, so when callers
+            # narrow `addresses` to just Safe addresses the cross-emitter pickup
+            # is dropped and setup rows end up with to=NULL_ADDRESS, breaking
+            # downstream safe_tx_hash computation. Append factory addresses so the
+            # filter still includes them.
+            # See iotexproject/iotex-transaction-service#10.
+            from ..indexers.safe_events_indexer import SafeEventsIndexer
+
+            if isinstance(indexer, SafeEventsIndexer):
+                factory_addresses = list(
+                    ProxyFactory.objects.values_list("address", flat=True)
+                )
+                addresses = list(addresses) + factory_addresses
         else:
             addresses = list(
                 indexer.database_queryset.values_list("address", flat=True)

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -17,6 +17,7 @@ from ..services import IndexServiceProvider
 from ..tasks import logger as task_logger
 from .factories import (
     MultisigTransactionFactory,
+    ProxyFactoryFactory,
     SafeContractFactory,
     SafeMasterCopyFactory,
 )
@@ -258,6 +259,35 @@ class TestCommands(TestCase):
                         current_block_number_mock.return_value,
                     )
                     self.assertEqual(find_relevant_elements_mock.call_count, 2)
+
+            # When reindexing an L2 indexer with explicit --addresses, the
+            # ProxyFactory addresses must also be appended so ProxyCreation
+            # events (emitted by the factory, not by the Safe) still match
+            # the getLogs filter. Without this, the setup InternalTx.to is
+            # left as NULL_ADDRESS and downstream safe_tx_hash computation
+            # breaks. See iotexproject/iotex-transaction-service#10.
+            IndexServiceProvider.del_singleton()
+            proxy_factory = ProxyFactoryFactory()
+            with self.assertLogs(logger_name, level="INFO") as cm:
+                with mock.patch.object(
+                    SafeEventsIndexer, "find_relevant_elements", return_value=[]
+                ) as find_relevant_elements_mock:
+                    target_safe_address = SafeContractFactory().address
+                    from_block_number = 300
+                    block_process_limit = 500
+                    call_command(
+                        command,
+                        f"--block-process-limit={block_process_limit}",
+                        f"--from-block-number={from_block_number}",
+                        f"--addresses={target_safe_address}",
+                        stdout=StringIO(),
+                    )
+                    expected_addresses = [target_safe_address, proxy_factory.address]
+                    find_relevant_elements_mock.assert_any_call(
+                        expected_addresses,
+                        from_block_number,
+                        from_block_number + block_process_limit - 1,
+                    )
         IndexServiceProvider.del_singleton()
 
     @mock.patch.object(

--- a/safe_transaction_service/history/tests/test_index_service.py
+++ b/safe_transaction_service/history/tests/test_index_service.py
@@ -158,3 +158,53 @@ class TestIndexService(EthereumTestCaseMixin, TestCase):
         self.assertEqual(SafeStatus.objects.count(), 0)
         self.assertEqual(SafeLastStatus.objects.count(), 0)
         self.assertEqual(MultisigTransaction.objects.count(), 2)
+
+    def test_is_unrelated_proxy_creation(self):
+        """ProxyCreation events for proxies not in the requested address set
+        are flagged as unrelated, so `_reindex` can drop them when the user
+        scoped `--addresses` to a specific Safe (see #10).
+        """
+        from ..services.index_service import _is_unrelated_proxy_creation
+
+        requested_address = Account.create().address
+        unrelated_address = Account.create().address
+        requested = {requested_address.lower()}
+
+        class _FakeIndexer:
+            def __init__(self, decoded):
+                self._decoded = decoded
+
+            def decode_element(self, log_receipt):
+                return self._decoded
+
+        # ProxyCreation for the requested Safe — should NOT be filtered.
+        related_indexer = _FakeIndexer(
+            {"event": "ProxyCreation", "args": {"proxy": requested_address}}
+        )
+        self.assertFalse(
+            _is_unrelated_proxy_creation(related_indexer, {}, requested)
+        )
+
+        # ProxyCreation for an unrelated Safe — should be filtered.
+        unrelated_indexer = _FakeIndexer(
+            {"event": "ProxyCreation", "args": {"proxy": unrelated_address}}
+        )
+        self.assertTrue(
+            _is_unrelated_proxy_creation(unrelated_indexer, {}, requested)
+        )
+
+        # Non-ProxyCreation event (e.g. SafeSetup) — never filtered, regardless
+        # of which address it concerns. Other indexer logic handles those.
+        safesetup_indexer = _FakeIndexer(
+            {"event": "SafeSetup", "args": {"singleton": unrelated_address}}
+        )
+        self.assertFalse(
+            _is_unrelated_proxy_creation(safesetup_indexer, {}, requested)
+        )
+
+        # Decoder returned None — leave the log in (don't drop logs we can't
+        # interpret).
+        undecodable_indexer = _FakeIndexer(None)
+        self.assertFalse(
+            _is_unrelated_proxy_creation(undecodable_indexer, {}, requested)
+        )


### PR DESCRIPTION
## Summary

Closes #10.

`reindex_master_copies --addresses <safe>` was dropping `ProxyCreation` events emitted by the proxy factory, breaking the `setup → singleton` cross-link in `SafeEventsIndexer._process_decoded_element`. Result: `history_safelaststatus.master_copy = 0x0`, `get_safe_version_from_master_copy()` returns `None`, `safe_tx_hash` falls back to the pre-1.3.0 EIP-712 domain (no `chainId`), and every newly-executed multisig duplicates as a phantom row while the user-proposed row stays stuck on "indexing" forever.

## Why this only fires for the reindex path

| Path | `IGNORE_ADDRESSES_ON_LOG_FILTER` | `getLogs` address filter | Picks up factory's `ProxyCreation`? |
|---|---|---|---|
| Default scheduled `index_safe_events_task` | `True` (class default) | (none — topics only) | ✅ yes |
| `reindex_master_copies --addresses <safe>` | force-set to `False` by `_reindex` | narrowed to `<safe>` | ❌ no |

The class default of `True` on `SafeEventsIndexer` (with the explanatory comment "Search for logs in every address (like the ProxyFactory)") exists for exactly this reason. `_reindex` flips it off to scope the scan, which is fine for `InternalTxIndexer` (L1, trace-based, single-emitter) but breaks the L2 cross-emitter cross-link.

## Fix

In `services/index_service.py::_reindex`, when the indexer is a `SafeEventsIndexer`, append every registered `ProxyFactory.address` to the filter alongside the user-supplied Safe addresses, so `ProxyCreation` logs still match.

\`\`\`python
if isinstance(indexer, SafeEventsIndexer):
    factory_addresses = list(
        ProxyFactory.objects.values_list("address", flat=True)
    )
    addresses = list(addresses) + factory_addresses
\`\`\`

## Test plan

- Added a unit test in \`test_commands.py::test_reindex_master_copies\` that exercises the L2 + custom \`--addresses\` path and asserts \`SafeEventsIndexer.find_relevant_elements\` is called with both the target Safe address AND the registered \`ProxyFactory\` address.
- Verified the failing flow on production beforehand: setup \`InternalTx\` for one Safe had \`to=0x0\`, \`history_safelaststatus.master_copy\` was zero, and a fresh execTransaction produced a phantom hash \`0xc31954…\` while the on-chain ExecutionSuccess event topic data clearly showed the correct hash \`0xee5a5fee…\`. After applying the workaround (directly patching \`master_copy\` to the correct singleton), re-running \`process_decoded_internal_txs_task\` produced no phantom row.

## Notes for reviewers

- Pre-existing AWS-era data on production (119 of 134 Safes) was unaffected because those were indexed live by the default scheduled task and got the correct cross-link.
- 15 Safes had their \`safelaststatus\` rows missing entirely from a pre-existing AWS gap; we backfilled \`master_copy\` for the 5 with related internal-txs by reading on-chain state directly. The 4 inactive ones will get backfilled organically when they next show activity.