### PR TITLE
fix(deps): use PEP 508 direct-URL syntax for safe-eth-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.5
 requests==2.31.0
-git+https://github.com/protofire/safe-eth-py.git@iotex#egg=safe-eth-py[django]
+safe-eth-py[django] @ git+https://github.com/protofire/safe-eth-py.git@iotex
 #safe-eth-py[django]==5.5.0
 web3==6.5.0


### PR DESCRIPTION
## Summary

The build broke on the merge of #11 because pip 26.x removed support for the legacy '#egg=name[extras]' fragment, which `requirements.txt` was still using for the protofire `safe-eth-py` fork:

\`\`\`
error: invalid-egg-fragment
× The 'safe-eth-py[django]' egg fragment is invalid
╰─> from 'git+https://github.com/protofire/safe-eth-py.git@iotex#egg=safe-eth-py[django]'

hint: Try using the Direct URL requirement syntax: 'name[extra] @ URL'
\`\`\`

This is unrelated to #11's code change — the Dockerfile runs \`pip install -U pip\` before installing deps, so every fresh build picks up the latest pip. As soon as pip 26.1.1 rolled out (~April 2026) any future Dockerfile build was going to break.

## Fix

Convert the line to the [PEP 508 direct-URL form](https://peps.python.org/pep-0508/) that newer pip versions require and older ones also accept:

\`\`\`
- git+https://github.com/protofire/safe-eth-py.git@iotex#egg=safe-eth-py[django]
+ safe-eth-py[django] @ git+https://github.com/protofire/safe-eth-py.git@iotex
\`\`\`

## Test plan

- [ ] Merge → \`build_image\` workflow on iotex-stg succeeds → new \`:iotex-stg\` image published
- [ ] Pull on the running VPS picks up the new image