### PR TITLE
build: pin setuptools<70 + own the safe-eth-py fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex \
 		" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps tmux postgresql-client \
-    && pip install -U --no-cache-dir wheel setuptools pip \
+    && pip install -U --no-cache-dir wheel "setuptools<70" pip \
     && pip install --no-cache-dir -r requirements.txt \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/* \

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.5
 requests==2.31.0
-safe-eth-py[django] @ git+https://github.com/protofire/safe-eth-py.git@iotex
+safe-eth-py[django] @ git+https://github.com/iotexproject/safe-eth-py.git@iotex
 #safe-eth-py[django]==5.5.0
 web3==6.5.0


### PR DESCRIPTION
## Summary

Bundle of two one-line build-pipeline fixes. Together they get the \`build_image\` workflow back to green so future \`:iotex-stg\` pushes actually produce a new image (the running image was last built August 2024).

### 1. Dockerfile: pin `setuptools<70`

\`gunicorn 20.1.0\` imports \`pkg_resources\` from setuptools. setuptools removed \`pkg_resources\` in 70.0 (June 2024). The Dockerfile's \`pip install -U setuptools\` pulled latest unconditionally, so any fresh build after June 2024 broke with:

\`\`\`
ModuleNotFoundError: No module named 'pkg_resources'
\`\`\`

during \`manage.py collectstatic\` (which imports the logging filter class → \`gunicorn.glogging\` → \`gunicorn.util\` → \`pkg_resources\`).

### 2. requirements.txt: swap protofire → iotexproject

Pull \`safe-eth-py\` from iotexproject's own fork instead of protofire's:

\`\`\`
- safe-eth-py[django] @ git+https://github.com/protofire/safe-eth-py.git@iotex
+ safe-eth-py[django] @ git+https://github.com/iotexproject/safe-eth-py.git@iotex
\`\`\`

The two repos point at the same commit (\`36e2d346\`). The diff from upstream \`safe-global/safe-eth-py\` is just two commits: IoTeX testnet master copies + an erc20 indexer topic-filter fix. Removes the supply-chain dependency on protofire's GitHub presence.

## Test plan

- [ ] Merge → \`build_image\` workflow succeeds → new \`:iotex-stg\` image lands on GHCR
- [ ] On prod VPS: \`docker compose pull\` picks up the new digest
- [ ] \`docker compose up -d\` recreates containers cleanly
- [ ] All hostnames continue to serve 200 (smoke test on safe.iotex.io / gateway / config / transaction / transaction-testnet)