### PR TITLE
chore(security): bump vulnerable Python deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.26.151
 cachetools==5.3.1
 celery==5.2.7
-django==4.2.2
+django==4.2.30
 django-cache-memoize==0.1.10
 django-celery-beat==2.5.0
 django-cors-headers==4.0.0
@@ -16,22 +16,22 @@ django-model-utils==4.3.1
 django-redis==5.2.0
 django-s3-storage==0.14.0
 django-timezone-field==5.1
-djangorestframework==3.14.0
+djangorestframework==3.15.2
 djangorestframework-camel-case==1.4.2
 docutils==0.20.1
 drf-yasg[validation]==1.21.5
 firebase-admin==6.2.0
 flower==1.2.0
-gunicorn[gevent]==20.1.0
+gunicorn[gevent]==23.0.0
 hexbytes==0.2.3
 hiredis==2.2.3
 packaging>=21.0
 pika==1.3.2
-pillow==9.5.0
+pillow==11.3.0
 psycogreen==1.0.2
 psycopg2==2.9.6
 redis==4.5.5
-requests==2.31.0
+requests==2.32.4
 safe-eth-py[django] @ git+https://github.com/iotexproject/safe-eth-py.git@iotex
 #safe-eth-py[django]==5.5.0
 web3==6.5.0


### PR DESCRIPTION
Bumps 5 direct dependencies in `requirements.txt` to address known CVEs.

| Package | From | To | Reason |
|---|---|---|---|
| `django` | 4.2.2 | 4.2.30 | Multiple 4.2 LTS security patches (XSS, ReDoS, header injection, etc.) |
| `djangorestframework` | 3.14.0 | 3.15.2 | CVE-2024-21520 — XSS via certain field formatters |
| `gunicorn[gevent]` | 20.1.0 | 23.0.0 | CVE-2024-1135 — HTTP request smuggling; 20.x EOL, 22.x first fixed |
| `pillow` | 9.5.0 | 11.3.0 | Multiple CVEs in 9.x / 10.x; no fix backported to 9.x |
| `requests` | 2.31.0 | 2.32.4 | CVE-2024-35195 — cert verification bypass via `verify=False` reuse |

### Cross-major bumps explained

- **gunicorn 20 → 23**: 20.x reached EOL with the request-smuggling fix only landing in 22.x+. Pinned to 23.0.0 to stay on a supported major.
- **pillow 9.5 → 11.3**: spans 2 majors, but the CVE backlog has no backport into 9.x. The 10.x → 11.x change is mostly internal C-extension cleanup; API surface used by this codebase (image open / save / thumbnail) is unchanged.

All other bumps stay within the existing major.

## Why target `iotex-stg`

`.github/workflows/build_image.yml` triggers Docker image builds on push to `iotex-stg` and on `v*.*.*` tags. Landing here means the fixed deps flow into the next `safe-tx-{web,nginx}:iotex-stg` image automatically.

(Note: the original branch was based off `iotex` tip `13e320c`; rebased onto `iotex-stg` for a clean fast-forward. `requirements.txt` is identical between the two branches — verified.)

## Test plan

- [ ] `python.yml` CI passes (tests against fresh deps)
- [ ] `build_image.yml` succeeds on merge / publishes new `iotex-stg` tag
- [ ] Staging stack pull + restart: `safe-tx-mainnet-web` + `safe-tx-mainnet-worker-indexer` reach steady state; indexer catches up to chain tip; no exception spike in `flower`

🤖 Generated with [Claude Code](https://claude.com/claude-code)