### PR TITLE
security: mark session/CSRF cookies Secure and trust the TLS proxy header

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -39,6 +39,24 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
 # https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 
+# Session/CSRF cookies were being issued without the Secure attribute, so a
+# browser would happily replay an admin session over plaintext. The deployment
+# is HTTPS-only (Cloudflare terminates TLS, the origin only accepts Cloudflare
+# IPs), so this is purely Django not being told.
+# https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-secure
+SESSION_COOKIE_SECURE = env.bool("DJANGO_SESSION_COOKIE_SECURE", default=True)
+CSRF_COOKIE_SECURE = env.bool("DJANGO_CSRF_COOKIE_SECURE", default=True)
+SESSION_COOKIE_HTTPONLY = env.bool("DJANGO_SESSION_COOKIE_HTTPONLY", default=True)
+
+# TLS is terminated upstream, so request.is_secure() is False without this and
+# Django treats every request as plaintext — which is also what makes the
+# scheme-qualified entries in CSRF_TRUSTED_ORIGINS unreliable on the admin
+# login POST. Trusting the header is safe only because the proxy sets it on
+# every request; keep the escape hatch for anyone running this without one.
+# https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+if env.bool("DJANGO_USE_X_FORWARDED_PROTO", default=True):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # SSO (tested with https://github.com/buzzfeed/sso)
 # ------------------------------------------------------------------------------
 # Be really careful when enabling SSO. If the `SSO_USERNAME_HEADER` can be spoofed


### PR DESCRIPTION
## What

In `config/settings/production.py`:

- `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY` — default `True`
- `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` — behind an env flag

All env-overridable, so a deployment without a TLS-terminating proxy can opt out.

## Why

Observed live on the IoTeX deployment:

```
$ curl -sSI https://transaction.safe.iotex.io/admin/login/ | grep -i set-cookie
set-cookie: csrftoken=...; expires=...; Max-Age=31449600; Path=/; SameSite=Lax
```

No `Secure`. Django's `SESSION_COOKIE_SECURE` and `CSRF_COOKIE_SECURE` both default
to `False` and this settings file never set them, so the admin session cookie could
be replayed over plaintext.

`SECURE_PROXY_SSL_HEADER` was `None`, so `request.is_secure()` was `False` on every
request even though TLS is terminated one hop up. That also undermines the
scheme-qualified `CSRF_TRUSTED_ORIGINS` entries on the admin login POST.

## Risk

- Trusting `X-Forwarded-Proto` is only sound when the proxy sets it on every
  request. That holds here (Caddy → Cloudflare, and the origin now drops
  non-Cloudflare traffic at the `DOCKER-USER` chain), hence the env escape hatch
  rather than a hard-coded value.
- Nothing here enables `SECURE_SSL_REDIRECT`, so no redirect loop is possible if
  the header is ever absent.
- Verify after deploy: the admin login flow still completes, and `Set-Cookie` now
  carries `Secure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)